### PR TITLE
build: fix hardcoding erl_interface path

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,6 +10,15 @@ GOTO :EOF
 
 :KnowErl
 
+IF DEFINED ERL_INTERFACE GOTO KnowErlInterface
+FOR /D %%D IN ("%ERL%\lib\erl_interface-*") DO IF EXIST "%%D\include\ei.h" SET ERL_INTERFACE=%%D
+IF DEFINED ERL_INTERFACE GOTO KnowErlInterface
+ECHO Could not find erlang interface headers. Please set the ERL_INTERFACE
+ECHO environment variable, .e.g. ERL_INTERFACE=%ERL%\lib\erl_interface-3.7.3
+PAUSE
+GOTO :EOF
+
+:KnowErlInterface
 
 IF DEFINED MINGW GOTO KnowMingw
 FOR /D %%D IN ("%ProgramFiles%\MinGW" C:\MinGW) DO IF EXIST "%%D\bin\gcc.exe" SET MINGW=%%D
@@ -19,7 +28,6 @@ PAUSE
 GOTO :EOF
 
 :KnowMingw
-
 
 IF DEFINED DOKAN GOTO KnowDokan
 FOR /D %%D IN ("%ProgramFiles%\Dokan\DokanLibrary") DO IF EXIST "%%D\dokan.h" SET DOKAN=%%D
@@ -33,8 +41,8 @@ GOTO :EOF
 SET PATH=%PATH%;%ERL%\bin;%MINGW%\bin
 
 SET CFLAGS=-Wall -DUNICODE -DWINVER=0x0500
-SET CFLAGS=%CFLAGS% -I "%DOKAN%" -I "%ERL%\usr\include" -I "%ERL%\lib\erl_interface-3.7.2\include"
-SET LDFLAGS=-L %DOKAN% -ldokan -L%ERL%\lib\erl_interface-3.7.2\lib -lei -lkernel32
+SET CFLAGS=%CFLAGS% -I "%DOKAN%" -I "%ERL%\usr\include" -I "%ERL_INTERFACE%\include"
+SET LDFLAGS=-L %DOKAN% -ldokan -L%ERL_INTERFACE%\lib -lei -lkernel32
 
 gcc -shared -o priv\erldokan_drv.dll %CFLAGS% c_src\dokan.def c_src\dokan.c %LDFLAGS%
 erlc -o ebin -I include src\erldokan.erl src\hello.erl


### PR DESCRIPTION
Different erlang installations come with different erl_interface
versions, and the erl_interface version number is part of the
path. Instead of hardcoding it detect it along with the rest
of the dependencies.
